### PR TITLE
fix: object deep cloning issue

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,7 +19,7 @@ export const Dashboard: React.FC = () => {
               if (existing) {
                 return existing;
               }
-              return condition;
+              return {...condition}; //need to return a new cloned object here
             }),
           },
         };


### PR DESCRIPTION
### Problem
This is a reference copy issue. When we are creating the source data in `reconcile`, the `checks` object is not being newly created, hence there is this referential bug.
### Fix
Fixed this issue by creating a new copy of the `checks` object by using the `... (spread)` operator right from the data source when it was created