### PR TITLE
fix: Switch toggle issue

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,7 +19,18 @@ export const Dashboard: React.FC = () => {
               if (existing) {
                 return existing;
               }
-              return condition;
+              /**
+               * Problem:
+               * `return condition;`
+               *
+               * We are returning the same object reference for different sources.
+               */
+
+              /**
+               * Solution:
+               * Using the spread operator to clone the object so we return a new object reference.
+               */
+              return { ...condition, passed: false };
             }),
           },
         };

--- a/src/components/Verifications.tsx
+++ b/src/components/Verifications.tsx
@@ -8,10 +8,43 @@ interface Props {
 
 export const Verifications: React.FC<Props> = ({ verifications, onChange }) => {
   const handleChange = (vIndex: number, cIndex: number, value: boolean) => {
-    const v = structuredClone(verifications);
-    
-    v[vIndex].eligibility.checks[cIndex].passed = value;
-    onChange(v);
+    /**
+     * Problem:
+     * `const updatedVerification = structuredClone(verifications);`
+     *
+     * `structuredClone` works on principle that if Object.is(orgObj.field1, orgObj.field2) is true then
+     * Object.is(cloneObj.field1, cloneObj.field2) should also be true.
+     *
+     * Hence, in our case where few eligibility `check` object of different sources have the same object reference then it will be same in the cloned object as well, hence causing the issue.
+     */
+
+    /**
+     * Solution 1: Using JSON.parse and JSON.stringify to clone the object.
+     *
+     * const updatedVerification = JSON.parse(JSON.stringify(verifications));
+     * updatedVerification[vIndex].eligibility.checks[cIndex].passed = value;
+     */
+
+    /**
+     * Solution 2: Using the spread operator to clone and update the object.
+     */
+
+    const updatedVerification = verifications.map((verification, verIndex) => {
+      if (verIndex !== vIndex) return verification;
+
+      return {
+        ...verification,
+        eligibility: {
+          ...verification.eligibility,
+          checks: verification.eligibility.checks.map((check, checkIndex) => {
+            if (checkIndex !== cIndex) return check;
+            return { ...check, passed: value };
+          }),
+        },
+      };
+    });
+
+    onChange(updatedVerification);
   };
 
   return (
@@ -26,8 +59,27 @@ export const Verifications: React.FC<Props> = ({ verifications, onChange }) => {
             <div className="flex flex-wrap">
               {verification.eligibility.checks.map((condition, cIndex) => {
                 return (
-                  <div className="p-px w-1/2" key={condition.name}>
+                  <div
+                    className="p-px w-1/2"
+                    /**
+                     * Problem (Unrelated to Switch issue):
+                     * `key={condition.name}`
+                     *
+                     * For different sources, the condition name can be same as well, hence use of same key for different child elements.
+                     */
+
+                    /**
+                     * Solution:
+                     * We should use unique key for each child element
+                     */
+                    key={`${verification.source}-${condition.name}`}
+                  >
                     <div
+                      /**
+                       * Problem (Unrelated to Switch issue):
+                       *
+                       * No need of `key` prop here as this is not a list element.
+                       */
                       key={condition.name}
                       className="flex flex-col bg-white p-4 rounded-lg"
                     >


### PR DESCRIPTION
## Summary:

### Switch Toggle Issue

1. Fixed the issue of modifying object having same reference in the [`handleChange`](https://github.com/msk4862/Arcane/blob/6fc2f58c1af5c8a274db42879b5fe8824af63164/src/components/Verifications.tsx#L11-L45) function.
2. Fixed the issue in [`reconcile`](https://github.com/msk4862/Arcane/blob/6fc2f58c1af5c8a274db42879b5fe8824af63164/src/components/Dashboard.tsx#L22-L33) function to ensure unique object references are getting returned for each `checks` object.

### `key` prop Issue (Unrelated to Switch Issue)

1. Children with same `key` prop while rendering [`checks` list](https://github.com/msk4862/Arcane/blob/6fc2f58c1af5c8a274db42879b5fe8824af63164/src/components/Verifications.tsx#L64-L74)
2. Unnecessary `key` prop used in [on non-list div](https://github.com/msk4862/Arcane/blob/6fc2f58c1af5c8a274db42879b5fe8824af63164/src/components/Verifications.tsx#L78-L82)